### PR TITLE
session storage now persists across tabs

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from 'next/font/google'
 import './globals.css'
 import 'lenis/dist/lenis.css'
 import { Partytown } from '@qwik.dev/partytown/react'
+import RouteTracker from '@/components/RouteTracker'
 
 const geistSans = Geist({
 	variable: '--font-geist-sans',
@@ -155,6 +156,7 @@ export default function RootLayout({
 			<body
 				className={`${geistSans.variable} ${geistMono.variable} antialiased`}
 			>
+				<RouteTracker />
 				{children}
 			</body>
 			<script

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,19 +11,38 @@ import { GallerySection } from '@/components/sections/GallerySection';
 import { Newsletter } from '@/components/sections/Newsletter';
 import { Footer } from '@/components/sections/Footer';
 
+const HOME_LOADER_STORAGE_KEY = 'hasSeenLoader';
+
+declare global {
+  interface Window {
+    __gdgCurrentPathname?: string;
+    __gdgPreviousPathname?: string;
+  }
+}
+
 export default function Home() {
   const [isLoading, setIsLoading] = useState(() => {
-    // will check once if user has used the loader in ts session 
+    // itll play the intro on full page loads, but skip it for clientside returns
+    // to the homepage after it has already been seen in any tab
     if (typeof window !== 'undefined') {
-      return !sessionStorage.getItem('hasSeenLoader');
+      const isClientSideReturn =
+        typeof window.__gdgCurrentPathname === 'string' &&
+        window.__gdgCurrentPathname !== '/';
+
+      if (!isClientSideReturn) {
+        return true;
+      }
+
+      return !localStorage.getItem(HOME_LOADER_STORAGE_KEY);
     }
+
     return true;
   });
 
   useEffect(() => {
-    // marking that user has seen the loader
+    // will mark that the intro has been seen for clientside navigations in any tab
     if (!isLoading && typeof window !== 'undefined') {
-      sessionStorage.setItem('hasSeenLoader', 'true');
+      localStorage.setItem(HOME_LOADER_STORAGE_KEY, 'true');
     }
   }, [isLoading]);
 

--- a/components/RouteTracker.tsx
+++ b/components/RouteTracker.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+import { useEffect } from 'react'
+
+declare global {
+	interface Window {
+		__gdgCurrentPathname?: string
+		__gdgPreviousPathname?: string
+	}
+}
+
+export default function RouteTracker() {
+	const pathname = usePathname()
+
+	useEffect(() => {
+		window.__gdgPreviousPathname = window.__gdgCurrentPathname
+		window.__gdgCurrentPathname = pathname
+	}, [pathname])
+
+	return null
+}


### PR DESCRIPTION
Home intro state now uses shared localStorage, so a visit in one tab is clearly visible to other tabs 

I added a small route tracker to distinguish full page has reloaded so it shows the intro and client side navigation back for skipping the intro if any tab has already seen it

results : 

tab A visits / : intro plays
tab B opens /newsletter and then navigates to / : intro will be skipped
reloading / still plays the intro

